### PR TITLE
Added Mac OS X build for sambamba

### DIFF
--- a/sambamba.rb
+++ b/sambamba.rb
@@ -3,11 +3,16 @@ require 'formula'
 class Sambamba < Formula
   homepage 'https://github.com/lomereiter/sambamba'
   version '0.4.3'
-  url 'https://github.com/lomereiter/sambamba/releases/download/v0.4.3/sambamba_v0.4.3_centos5.tar.bz2'
-  sha1 'd181e952c9d63ac7391fbb9a5ba4119d24e1c69d'
+
+  if OS.mac?
+    url 'https://github.com/lomereiter/sambamba/releases/download/v0.4.3/sambamba_v0.4.3_osx.tar.bz2'
+    sha1 'f0ca3c03a1a17673c35fa5e03665fce3fdc8f3b8'
+  else
+    url 'https://github.com/lomereiter/sambamba/releases/download/v0.4.3/sambamba_v0.4.3_centos5.tar.bz2'
+    sha1 'd181e952c9d63ac7391fbb9a5ba4119d24e1c69d'
+  end
 
   def install
-    raise 'sambamba not yet supported for MacOSX' if OS.mac?
     bin.install 'sambamba_v0.4.3' => 'sambamba'
   end
 


### PR DESCRIPTION
From now on, release builds for Mac OS X are done on Travis CI (which currently uses 10.8.5 if it matters).
